### PR TITLE
added with-builtinmodules

### DIFF
--- a/singular/singular.cygport
+++ b/singular/singular.cygport
@@ -31,10 +31,10 @@ src_compile()
           --enable-syzextra \
           --enable-gfanlib \
           --disable-python \
+          --with-builtinmodules=syzextra,gfanlib \
           --with-ntl=/usr/ \
           --with-flint=/usr/ \
-          LDFLAGS="-L/usr/lib -L/usr/local/bin" \
-          --disable-silent-rules
+          LDFLAGS="-L/usr/lib -L/usr/local/bin"
   cygmake
 }
 


### PR DESCRIPTION
Hi Marco, can you please try it again with this changed configuration options?

I removed "--disable-silent-rules", because it was only handy for development purposes, but serves no real purpose apart from that. 

I also set syzextra and gfanlib to builtinmodules, which gets rid of the need to load a shared module from inside Singular to use them.
